### PR TITLE
Add Google authentication flow and guard cloud-only actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         const app = firebase.initializeApp(firebaseConfig);
         const database = firebase.database();
         const auth = firebase.auth();
+        const provider = new firebase.auth.GoogleAuthProvider();
 
         const Icon = ({ name, size = 20, className = "" }) => {
             const icons = {
@@ -77,21 +78,37 @@
             const [panStart, setPanStart] = useState({ x: 0, y: 0 });
             const [user, setUser] = useState(null);
             const [syncStatus, setSyncStatus] = useState('connecting');
+            const mapsRefRef = useRef(null);
             const canvasRef = useRef(null);
 
             useEffect(() => {
-                // Sign in anonymously
-                auth.signInAnonymously()
-                    .then((userCredential) => {
-                        setUser(userCredential.user);
+                const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
+                    if (firebaseUser) {
+                        setUser(firebaseUser);
                         setSyncStatus('connected');
-                        loadMapsFromFirebase(userCredential.user.uid);
-                    })
-                    .catch((error) => {
-                        console.error("Auth error:", error);
-                        setSyncStatus('error');
+                        loadMapsFromFirebase(firebaseUser.uid);
+                    } else {
+                        setUser(null);
+                        setSyncStatus('signedOut');
+                        if (mapsRefRef.current) {
+                            mapsRefRef.current.off();
+                            mapsRefRef.current = null;
+                        }
+                        setMaps([]);
+                        setCurrentMap(null);
+                        setNodes([]);
+                        setConnections([]);
                         loadFromLocalStorage();
-                    });
+                    }
+                });
+
+                return () => {
+                    unsubscribe();
+                    if (mapsRefRef.current) {
+                        mapsRefRef.current.off();
+                        mapsRefRef.current = null;
+                    }
+                };
             }, []);
 
             const loadFromLocalStorage = () => {
@@ -105,8 +122,17 @@
             };
 
             const loadMapsFromFirebase = (userId) => {
+                if (mapsRefRef.current) {
+                    mapsRefRef.current.off();
+                    mapsRefRef.current = null;
+                }
+
                 const mapsRef = database.ref(`users/${userId}/maps`);
-                mapsRef.once('value', (snapshot) => {
+                mapsRefRef.current = mapsRef;
+
+                let isInitialLoad = true;
+
+                mapsRef.on('value', (snapshot) => {
                     const data = snapshot.val();
                     if (data) {
                         const mapsArray = Object.keys(data).map(key => {
@@ -119,37 +145,23 @@
                                 connections: mapData.connections || []
                             };
                         }).filter(map => map.nodes.length > 0); // Remove empty maps
-                        
+
                         mapsArray.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified));
                         setMaps(mapsArray);
-                        
-                        if (mapsArray.length > 0) {
-                            loadMap(mapsArray[0]);
-                        } else {
-                            initializeNewMap();
+
+                        if (isInitialLoad) {
+                            if (mapsArray.length > 0) {
+                                loadMap(mapsArray[0]);
+                            } else {
+                                initializeNewMap();
+                            }
                         }
-                    } else {
+                    } else if (isInitialLoad) {
                         initializeNewMap();
+                        setMaps([]);
                     }
-                });
-                
-                // Listen for changes after initial load
-                mapsRef.on('value', (snapshot) => {
-                    const data = snapshot.val();
-                    if (data) {
-                        const mapsArray = Object.keys(data).map(key => {
-                            const mapData = data[key];
-                            return {
-                                ...mapData,
-                                id: key,
-                                nodes: mapData.nodes || [],
-                                connections: mapData.connections || []
-                            };
-                        }).filter(map => map.nodes.length > 0);
-                        
-                        mapsArray.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified));
-                        setMaps(mapsArray);
-                    }
+
+                    isInitialLoad = false;
                 });
             };
 
@@ -181,21 +193,24 @@
                     lastModified: new Date().toISOString()
                 };
 
+                if (!user) {
+                    alert('Sign in to sync maps to the cloud. Saving locally instead.');
+                    setSyncStatus('signedOut');
+                    saveToLocalStorage(mapData);
+                    return;
+                }
+
                 setSyncStatus('saving');
 
-                if (user) {
-                    try {
-                        const mapId = currentMap?.id || `map_${Date.now()}`;
-                        await database.ref(`users/${user.uid}/maps/${mapId}`).set(mapData);
-                        setCurrentMap({ ...mapData, id: mapId });
-                        setSyncStatus('synced');
-                        setTimeout(() => setSyncStatus('connected'), 2000);
-                    } catch (error) {
-                        console.error("Save error:", error);
-                        setSyncStatus('error');
-                        saveToLocalStorage(mapData);
-                    }
-                } else {
+                try {
+                    const mapId = currentMap?.id || `map_${Date.now()}`;
+                    await database.ref(`users/${user.uid}/maps/${mapId}`).set(mapData);
+                    setCurrentMap({ ...mapData, id: mapId });
+                    setSyncStatus('synced');
+                    setTimeout(() => setSyncStatus('connected'), 2000);
+                } catch (error) {
+                    console.error("Save error:", error);
+                    setSyncStatus('error');
                     saveToLocalStorage(mapData);
                 }
             };
@@ -226,13 +241,26 @@
             const deleteMap = async (mapId) => {
                 if (!confirm('Are you sure you want to delete this map?')) return;
 
-                if (user) {
-                    try {
-                        await database.ref(`users/${user.uid}/maps/${mapId}`).remove();
-                    } catch (error) {
-                        console.error("Delete error:", error);
-                        alert('Error deleting map from cloud');
+                if (!user) {
+                    alert('Sign in to delete cloud maps. Removing from local storage instead.');
+                    const remainingMaps = maps.filter(m => m.id !== mapId);
+                    setMaps(remainingMaps);
+                    localStorage.setItem('mindMaps', JSON.stringify(remainingMaps));
+                    if (currentMap?.id === mapId) {
+                        if (remainingMaps.length > 0) {
+                            loadMap(remainingMaps[0]);
+                        } else {
+                            initializeNewMap();
+                        }
                     }
+                    return;
+                }
+
+                try {
+                    await database.ref(`users/${user.uid}/maps/${mapId}`).remove();
+                } catch (error) {
+                    console.error("Delete error:", error);
+                    alert('Error deleting map from cloud');
                 }
 
                 if (currentMap?.id === mapId) {
@@ -361,7 +389,8 @@
                     connected: { icon: 'cloud', color: 'text-green-400', text: 'Cloud Connected', animate: false },
                     saving: { icon: 'cloud', color: 'text-blue-400', text: 'Saving...', animate: true },
                     synced: { icon: 'cloud', color: 'text-green-400', text: 'Synced ✓', animate: false },
-                    error: { icon: 'cloudOff', color: 'text-red-400', text: 'Offline Mode', animate: false }
+                    error: { icon: 'cloudOff', color: 'text-red-400', text: 'Offline Mode', animate: false },
+                    signedOut: { icon: 'cloudOff', color: 'text-yellow-300', text: 'Sign in to sync', animate: false }
                 };
                 const status = indicators[syncStatus] || indicators.connected;
                 return (
@@ -433,9 +462,48 @@
                             <button onClick={initializeNewMap} className="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">
                                 New Map
                             </button>
-                            {user && (
-                                <button 
+                            {user ? (
+                                <button
                                     onClick={async () => {
+                                        setSyncStatus('connecting');
+                                        try {
+                                            await auth.signOut();
+                                            setSyncStatus('signedOut');
+                                        } catch (error) {
+                                            console.error('Sign-out error:', error);
+                                            setSyncStatus('error');
+                                            alert('Error signing out. Please try again.');
+                                        }
+                                    }}
+                                    className="px-4 py-2 bg-orange-500 text-gray-900 rounded hover:bg-orange-400"
+                                >
+                                    Sign Out {user.displayName ? `(${user.displayName})` : ''}
+                                </button>
+                            ) : (
+                                <button
+                                    onClick={async () => {
+                                        setSyncStatus('connecting');
+                                        try {
+                                            await auth.signInWithPopup(provider);
+                                        } catch (error) {
+                                            console.error('Sign-in error:', error);
+                                            setSyncStatus('error');
+                                            alert('Google sign-in failed. Please try again.');
+                                            loadFromLocalStorage();
+                                        }
+                                    }}
+                                    className="px-4 py-2 bg-yellow-400 text-gray-900 rounded hover:bg-yellow-300"
+                                >
+                                    Sign in with Google
+                                </button>
+                            )}
+                            {user && (
+                                <button
+                                    onClick={async () => {
+                                        if (!user) {
+                                            alert('Sign in to reset cloud data.');
+                                            return;
+                                        }
                                         if (confirm('Clear all cloud data and start fresh? This cannot be undone!')) {
                                             try {
                                                 await database.ref(`users/${user.uid}/maps`).remove();


### PR DESCRIPTION
## Summary
- add a Google auth provider and migrate to an auth state listener that loads either cloud or local maps
- add toolbar controls for signing in/out with status updates and listener cleanup
- guard save/delete/reset actions to show helpful messaging when cloud sync is unavailable

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ddfec952a4832e85efcd3c883c7da1