### PR TITLE
Improve canvas panning and refresh UI styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,15 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
-        body { 
-            margin: 0; 
-            padding: 0; 
+        body {
+            margin: 0;
+            padding: 0;
             overflow: hidden;
             touch-action: none;
+            background: radial-gradient(circle at 20% 20%, rgba(59,130,246,0.08), transparent 35%),
+                        radial-gradient(circle at 80% 0%, rgba(16,185,129,0.08), transparent 30%),
+                        radial-gradient(circle at 50% 80%, rgba(236,72,153,0.08), transparent 30%),
+                        #0f172a;
         }
         @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
         .animate-pulse { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
@@ -43,6 +47,13 @@
         @keyframes nodeAppear {
             from { transform: scale(0); opacity: 0; }
             to { transform: scale(1); opacity: 1; }
+        }
+        .mindmap-canvas {
+            background-image:
+                linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px),
+                linear-gradient(180deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+            background-size: 32px 32px;
+            backdrop-filter: blur(12px);
         }
     </style>
 </head>
@@ -90,7 +101,8 @@
                 target: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>,
                 search: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>,
                 undo: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>,
-                redo: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7"/></svg>
+                redo: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3l3 2.7"/></svg>,
+                refresh: <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"/><path d="M20.49 15A9 9 0 0 1 5.64 18.36L1 14"/></svg>
             };
             return <span className={className}>{icons[name]}</span>;
         };
@@ -408,11 +420,17 @@
             };
 
             const centerView = () => {
-                const centerNode = nodes.find(n => n.isCenter);
-                if (centerNode) {
-                    setPan({ x: -centerNode.x + window.innerWidth / 2 / zoom - 75, y: -centerNode.y + window.innerHeight / 2 / zoom - 30 });
-                    showToast('View centered', 'success');
+                const targetNode = selectedNode || nodes.find(n => n.isCenter);
+                if (targetNode) {
+                    setPan({ x: -targetNode.x + window.innerWidth / 2 / zoom - 75, y: -targetNode.y + window.innerHeight / 2 / zoom - 30 });
+                    showToast(selectedNode ? 'Centered on selection' : 'View centered', 'success');
                 }
+            };
+
+            const resetView = () => {
+                setZoom(1);
+                setPan({ x: 0, y: 0 });
+                showToast('View reset', 'success');
             };
 
             const handleLogout = async () => {
@@ -677,7 +695,8 @@
             };
 
             const startPanning = (e) => {
-                if (spacePressed || e.target === canvasRef.current) {
+                const isCanvasSurface = e.target === canvasRef.current || e.target.dataset?.surface === 'true';
+                if (spacePressed || isCanvasSurface) {
                     setIsPanning(true);
                     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
                     const clientY = e.touches ? e.touches[0].clientY : e.clientY;
@@ -792,6 +811,9 @@
                             <button onClick={centerView} className={`p-2 ${btnBg} ${textPrimary} rounded`} title="Center View">
                                 <Icon name="target" />
                             </button>
+                            <button onClick={resetView} className={`p-2 ${btnBg} ${textPrimary} rounded`} title="Reset Zoom & Position">
+                                <Icon name="refresh" />
+                            </button>
                             <button onClick={undo} disabled={historyIndex <= 0} className={`p-2 ${btnBg} ${textPrimary} rounded disabled:opacity-30`} title="Undo (Ctrl+Z)">
                                 <Icon name="undo" />
                             </button>
@@ -861,6 +883,10 @@
                                 <button onClick={centerView} className={`p-3 ${btnBg} ${textPrimary} rounded text-sm flex flex-col items-center gap-1`}>
                                     <Icon name="target" />
                                     <span className="text-xs">Center</span>
+                                </button>
+                                <button onClick={resetView} className={`p-3 ${btnBg} ${textPrimary} rounded text-sm flex flex-col items-center gap-1`}>
+                                    <Icon name="refresh" />
+                                    <span className="text-xs">Reset</span>
                                 </button>
                                 <button onClick={undo} disabled={historyIndex <= 0} className={`p-3 ${btnBg} ${textPrimary} rounded text-sm flex flex-col items-center gap-1 disabled:opacity-30`}>
                                     <Icon name="undo" />
@@ -961,9 +987,9 @@
                     )}
 
                     {/* Canvas */}
-                    <div 
-                        ref={canvasRef} 
-                        className="flex-1 relative overflow-hidden cursor-move" 
+                    <div
+                        ref={canvasRef}
+                        className="flex-1 relative overflow-hidden cursor-move mindmap-canvas"
                         onMouseMove={handleMouseMove}
                         onMouseDown={startPanning}
                         onMouseUp={handleMouseUp}
@@ -972,7 +998,7 @@
                         onTouchMove={handleTouchMove}
                         onTouchEnd={handleTouchEnd}
                     >
-                        <svg className="absolute inset-0 w-full h-full pointer-events-none">
+                        <svg className="absolute inset-0 w-full h-full pointer-events-none" data-surface="true">
                             <g transform={`translate(${pan.x * zoom}, ${pan.y * zoom}) scale(${zoom})`}>
                                 {connections.map((conn, idx) => {
                                     const fromNode = nodes.find(n => n.id === conn.from);
@@ -983,7 +1009,7 @@
                             </g>
                         </svg>
 
-                        <div className="absolute inset-0" style={{ transform: `translate(${pan.x * zoom}px, ${pan.y * zoom}px) scale(${zoom})`, transformOrigin: '0 0' }}>
+                        <div className="absolute inset-0" data-surface="true" style={{ transform: `translate(${pan.x * zoom}px, ${pan.y * zoom}px) scale(${zoom})`, transformOrigin: '0 0' }}>
                             {nodes.map(node => (
                                 <div 
                                     key={node.id} 
@@ -1036,10 +1062,10 @@
                     <div className={`${headerBg} border-t p-2 text-xs sm:text-sm ${textMuted}`}>
                         <div className="flex items-center justify-between gap-2">
                             <p className="hidden sm:block">
-                                <strong className={textPrimary}>Tip:</strong> Hold <kbd className={`px-2 py-1 ${btnBg} rounded`}>Space</kbd> + drag to pan | <kbd className={`px-2 py-1 ${btnBg} rounded`}>Ctrl+S</kbd> to save
+                                <strong className={textPrimary}>Tip:</strong> Drag the background or hold <kbd className={`px-2 py-1 ${btnBg} rounded`}>Space</kbd> to pan · <kbd className={`px-2 py-1 ${btnBg} rounded`}>Ctrl+S</kbd> to save
                             </p>
                             <p className="sm:hidden truncate">
-                                Hold Space + drag to pan
+                                Drag the background or hold Space to pan
                             </p>
                             <div className="flex items-center gap-2 sm:gap-4">
                                 <label className="hidden sm:flex items-center gap-2 cursor-pointer">


### PR DESCRIPTION
## Summary
- allow panning from any empty canvas surface without requiring the center node
- add reset view control and updated centering behavior that prioritizes the selected node
- refresh canvas aesthetics with a subtle grid/gradient backdrop and updated tips

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ebf5dadc0832e929414f873bcdade)